### PR TITLE
Create env file if it doesn't exist

### DIFF
--- a/playground/server.js
+++ b/playground/server.js
@@ -1,5 +1,10 @@
 // Transpile all code following this line with babel and use 'env' (aka ES6) preset.
 require('babel-register')();
 
+// Create empty env file if it doesn't exist
+const fs = require('fs');
+if (!fs.existsSync('./integrations/env.json')) {
+  fs.writeFileSync('./integrations/env.json', '{}');
+}
 // Import the rest of our application.
 module.exports = require('./src/index.js');


### PR DESCRIPTION
Instead of throwing the following error when running `yarn serve`, create an empty `env.json`.

![image](https://user-images.githubusercontent.com/17952318/61218890-555ebc80-a713-11e9-84ee-cb0d58569b20.png)
