### PR TITLE
Fixed error handling

### DIFF
--- a/integrations/transportation/ryanair.js
+++ b/integrations/transportation/ryanair.js
@@ -19,7 +19,8 @@ async function logIn(username, password) {
     });
 
   if (!res.ok) {
-    throw new HTTPError(res.text, res.status);
+    const text = await res.text();
+    throw new HTTPError(text, res.status);
   }
 
   return {
@@ -87,7 +88,8 @@ async function getPastBookings(customerId, token) {
     .set('X-Auth-Token', token);
 
   if (!pastBookings.ok) {
-    throw new HTTPError(pastBookings.text, pastBookings.status);
+    const text = await pastBookings.text();
+    throw new HTTPError(text, pastBookings.status);
   }
   return pastBookings.body.bookings.filter(entry => entry.status === 'Confirmed');
 }

--- a/integrations/transportation/wizzair.js
+++ b/integrations/transportation/wizzair.js
@@ -40,7 +40,8 @@ async function logIn(username, password) {
     });
 
   if (!res.ok) {
-    throw new HTTPError(res.text, res.status);
+    const text = await res.text();
+    throw new HTTPError(text, res.status);
   }
   return {};
 }
@@ -57,7 +58,8 @@ async function getPastBookings() {
     });
 
   if (!pastBookings.ok) {
-    throw new HTTPError(pastBookings.text, pastBookings.status);
+    const text = await pastBookings.text();
+    throw new HTTPError(text, pastBookings.status);
   }
 
   return { 
@@ -89,9 +91,10 @@ async function getAllFlights(booking) {
             flight: res.body.returnFlight || false,
             pnr: res.body.pnr,
           });
-        }, ((res) => {
+        }, (async (res) => {
           if (!res.ok) {
-            throw new HTTPError(res.text, res.status);
+            const text = await res.text();
+            throw new HTTPError(text, res.status);
           }
         })
       );


### PR DESCRIPTION
A slight mistake on my part, it turns out awaiting `res.text()` was the way to go in error handling as it's connected to `HTTPError`'s super constructor :no_good: Without that, errors don't work properly. @FelixDQ , you were right 😂 I reverted the changes in both Wizzair and Ryanair