### PR TITLE
Fix bug where no oyster cards present, add contactless

### DIFF
--- a/integrations/transportation/tfl.js
+++ b/integrations/transportation/tfl.js
@@ -6,7 +6,7 @@ import env from '../loadEnv';
 const LOGIN_PATH = 'https://account.tfl.gov.uk/api/login';
 const BASE_PATH = 'https://mobileapi.tfl.gov.uk';
 
-function generateActivities(travelDays) {
+function generateOysterActivities(travelDays) {
   const activities = [];
   travelDays.forEach((day) => {
     day.Journeys.forEach((journey) => {
@@ -26,6 +26,139 @@ function generateActivities(travelDays) {
     });
   });
   return activities;
+}
+
+async function fetchOysterData(accessToken, oysterCardNumber, startMoment, endMoment) {
+  // Max 7 days data fetch allowed
+  return fetch(`${BASE_PATH}/Cards/Oyster/Journeys?startDate=${startMoment.format(moment.HTML5_FMT.DATE)}&endDate=${endMoment.format(moment.HTML5_FMT.DATE)}`, {
+    method: 'get',
+    headers: {
+      'x-zumo-auth': accessToken,
+      oystercardnumber: oysterCardNumber,
+    },
+  })
+    .catch((e) => {
+      throw new HTTPError(e);
+    });
+}
+
+async function fetchOysterCardTravelDays(newState) {
+  const { oysterCardNumbers, accessToken } = newState;
+  const today = moment().startOf('day');
+
+  const startDate = newState.lastUpdate
+    ? moment(newState.lastUpdate).startOf('day')
+    : moment().subtract(56, 'days').startOf('day'); // Not sure what max date range is... more than for oyster though
+
+  // Array put the fetch promises into to be resolved later
+  const apiPromises = [];
+
+  oysterCardNumbers.forEach((oysterCardNumber) => {
+    // First, get most recent data (between startDate and today)
+    let fetchStart = startDate;
+
+    while (fetchStart < today) {
+      const fetchEnd = moment(fetchStart).add(6, 'days') > today
+        ? today
+        : moment(fetchStart).add(6, 'days'); // Make sure query is no further than today
+
+      apiPromises.push(
+        fetchOysterData(
+          accessToken,
+          oysterCardNumber,
+          fetchStart,
+          fetchEnd
+        )
+          .then(response => response.json())
+      );
+      // Add one day to the end date to get the new start date
+      fetchStart = moment(fetchEnd).add(1, 'days');
+    }
+  });
+  try {
+    const apiResponses = await Promise.all(apiPromises);
+    return apiResponses.reduce((accumulator, json) => (json && json.TravelDays.length > 0 ? [...accumulator, ...json.TravelDays] : accumulator), []);
+  } catch (err) {
+    throw new HTTPError(err);
+  }
+}
+
+function generateContactlessActivities(travelDays) {
+  const activities = [];
+  travelDays.forEach((day) => {
+    day.Journeys.forEach((journey) => {
+      activities.push({
+        id: journey.StartTime, // a string that uniquely represents this activity
+        datetime: journey.StartTime, // a javascript Date object that represents the start of the activity
+        durationHours: journey.EndTime && moment(journey.EndTime).diff(moment(journey.StartTime)) / (60 * 60 * 1000), // a floating point that represents the duration of the activity in decimal hours
+        distanceKilometers: null, // a floating point that represents the amount of kilometers traveled (https://www.whatdotheyknow.com/request/bus_passenger_journey_times)
+        activityType: ACTIVITY_TYPE_TRANSPORTATION,
+        transportationMode: TRANSPORTATION_MODE_PUBLIC_TRANSPORT, // a variable (from definitions.js) that represents the transportation mode
+        carrier: 'Transport For London', // (optional) a string that represents the transportation company
+        departureStation: journey.Destination === null ? 'Bus' : journey.Origin, // (for other travel types) a string that represents the original starting point
+        destinationStation: journey.Destination === null ? 'Bus' : journey.Destination, // (for other travel types) a string that represents the final destination
+      });
+    });
+  });
+  return activities;
+}
+
+async function fetchContactlessData(accessToken, contactlessCardId, startMoment, endMoment) {
+  const url = `${BASE_PATH}/contactless/statements/journeys`;
+  const opts = {
+    method: 'get',
+    headers: {
+      'x-zumo-auth': accessToken,
+      'contactless-card-id': contactlessCardId,
+      'from-date': startMoment.format(moment.HTML5_FMT.DATE),
+      'to-date': endMoment.format(moment.HTML5_FMT.DATE),
+    },
+  };
+  return fetch(url, opts)
+    .catch((e) => {
+      throw new HTTPError(e);
+    });
+}
+
+async function fetchContactlessCardTravelDays(newState) {
+  const { contactlessCardIds, accessToken } = newState;
+  const today = moment().startOf('day');
+
+  const startDate = newState.lastUpdate
+    ? moment(newState.lastUpdate).startOf('day')
+    : moment().subtract(100, 'days').startOf('day'); // Not sure what max date range is... more than for oyster though
+
+  // Array put the fetch promises into to be resolved later
+  const apiPromises = [];
+
+  contactlessCardIds.forEach((contactlessCardId) => {
+    let fetchStart = startDate;
+
+    while (fetchStart < today) {
+      const fetchEnd = moment(fetchStart).add(30, 'days') > today
+        ? today
+        : moment(fetchStart).add(30, 'days'); // Make sure query is no further than today
+
+      apiPromises.push(
+        fetchContactlessData(
+          accessToken,
+          contactlessCardId,
+          fetchStart,
+          fetchEnd
+        )
+          .then(response => response.json())
+      );
+      // Add one day to the end date to get the new fetch start
+      fetchStart = moment(fetchEnd).add(1, 'days');
+    }
+  });
+  try {
+    const apiResponses = await Promise.all(apiPromises);
+
+    return apiResponses.reduce((accumulator, json) => (json && json.Days.length > 0 ? [...accumulator, ...json.Days] : accumulator), []);
+  } catch (err) {
+    throw new HTTPError(err);
+  }
 }
 
 async function connect(requestLogin) {
@@ -72,20 +205,6 @@ async function connect(requestLogin) {
     accessToken: apiTokenResponse.access_token,
     tokenExpiresAt: apiTokenResponse.expires_in * 1000 + Date.now(),
   };
-}
-
-async function getOysterData(accessToken, oysterCardNumber, startMoment, endMoment) {
-  // Max 7 days data fetch allowed
-  return fetch(`${BASE_PATH}/Cards/Oyster/Journeys?startDate=${startMoment.format(moment.HTML5_FMT.DATE)}&endDate=${endMoment.format(moment.HTML5_FMT.DATE)}`, {
-    method: 'get',
-    headers: {
-      'x-zumo-auth': accessToken,
-      oystercardnumber: oysterCardNumber,
-    },
-  })
-    .catch((e) => {
-      throw new HTTPError(e);
-    });
 }
 
 async function collect(state) {
@@ -147,44 +266,16 @@ async function collect(state) {
     ? contactlessCards.map(cc => cc.Id)
     : [];
 
-  const today = moment().startOf('day');
-  let startDate = state.lastUpdate ? moment(state.lastUpdate).startOf('day') : moment().subtract(56, 'days').startOf('day'); // Max data range is 56 days
 
-  if (newState.oysterCardNumbers && newState.oysterCardNumbers.length > 0) {
-    // First, get most recent data (between startDate and today)
-    const apiPromises = [];
-    while (startDate < today) {
-      /* eslint-disable no-await-in-loop */
-      // Can only query 7 days at a time on this api:
-      const oneWeekEndDate = moment(startDate).add(6, 'days'); // 6 days as it is inclusive
-      const adjustedEndDate = oneWeekEndDate > today ? today : oneWeekEndDate; // Make sure query is no further than today
-      apiPromises.push(
-        getOysterData(
-          newState.accessToken,
-          newState.oysterCardNumbers[0],
-          startDate,
-          adjustedEndDate
-        )
-          .then(response => response.json())
-      );
-      // Add one day to the end date to get the new start date
-      startDate = moment(adjustedEndDate).add(1, 'days');
-    }
+  const oysterCardTravelDays = await fetchOysterCardTravelDays(newState);
+  const contactlessCardTravelDays = await fetchContactlessCardTravelDays(newState);
+  const activities = [
+    ...generateOysterActivities(oysterCardTravelDays),
+    ...generateContactlessActivities(contactlessCardTravelDays),
+  ];
 
-    let activities = [];
-    try {
-      const apiResponses = await Promise.all(apiPromises);
-      const allTravelDays = apiResponses.reduce((accumulator, json) => (json && json.TravelDays.length > 0 ? [...accumulator, ...json.TravelDays] : accumulator), []);
-      activities = generateActivities(allTravelDays);
-      newState.lastUpdate = new Date(); // Set the last update so we don't have to fetch all the data on the next collect()
-    } catch (e) {
-      throw new HTTPError(e);
-    }
-
-    return { activities, state: newState };
-  }
-
-  return { activities: [], state: newState };
+  newState.lastUpdate = new Date(); // Set the last update so we don't have to fetch all the data on the next collect()
+  return { activities, state: newState };
 }
 
 async function disconnect() {

--- a/integrations/transportation/tfl.js
+++ b/integrations/transportation/tfl.js
@@ -124,9 +124,28 @@ async function collect(state) {
       throw new HTTPError(e);
     });
 
-  const oysterCards = oysterCardResponse.OysterCards;
+  // Update contactless cards
+  const contactlessCardResponse = await fetch(`${BASE_PATH}/Contactless/Cards`, {
+    method: 'get',
+    headers: {
+      'x-zumo-auth': newState.accessToken,
+    },
+  })
+    .then(response => response.json())
+    .catch((e) => {
+      throw new HTTPError(e);
+    });
 
-  newState.oysterCardNumbers = oysterCards.map(oc => oc.OysterCardNumber);
+  const oysterCards = oysterCardResponse.OysterCards;
+  const contactlessCards = contactlessCardResponse;
+
+  newState.oysterCardNumbers = oysterCards && oysterCards.length > 0
+    ? oysterCards.map(oc => oc.OysterCardNumber)
+    : [];
+
+  newState.contactlessCardIds = contactlessCards && contactlessCards.length > 0
+    ? contactlessCards.map(cc => cc.Id)
+    : [];
 
   const today = moment().startOf('day');
   let startDate = state.lastUpdate ? moment(state.lastUpdate).startOf('day') : moment().subtract(56, 'days').startOf('day'); // Max data range is 56 days


### PR DESCRIPTION
The first fix is to make sure the integration doesn't error out like in #260 . Secondly, we should be pulling through contactless data as well as oyster card data as that is a very popular way of paying for journeys. 

I need to pay for some journeys on my contactless card this week so I can see the data structure. Once I've done that, I'll ensure we loop through all Oyster and contactless cards on the account and aggregate all the journeys