### PR TITLE
replaced source lables with publication instead of title of the publication

### DIFF
--- a/co2eq/hotelpercountry.js
+++ b/co2eq/hotelpercountry.js
@@ -5,7 +5,7 @@ export const modelVersion = '1';
 export const explanation = {
   text: 'Calculations take into account the emissions of a stay depending of the country',
   links: [
-    { label: 'DEFRA (2009)', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
+    { label: 'UK GOV DEFRA (2009)', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
   ],
 };
 

--- a/co2eq/hotelpercountry.js
+++ b/co2eq/hotelpercountry.js
@@ -5,7 +5,7 @@ export const modelVersion = '1';
 export const explanation = {
   text: 'Calculations take into account the emissions of a stay depending of the country',
   links: [
-    { label: 'UK Government Conversion Factor', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
+    { label: 'DEFRA (2009)', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
   ],
 };
 

--- a/co2eq/lodging.js
+++ b/co2eq/lodging.js
@@ -10,7 +10,7 @@ export const modelVersion = '1';
 export const explanation = {
   text: 'Calculations take into account the energy usage of a stay',
   links: [
-    { label: 'South Pole', href: 'https://shop.southpolecarbon.com/uploads/assets/en/_Overnight%20Stays.pdf' },
+    { label: 'DEFRA (2009)', href: 'https://shop.southpolecarbon.com/uploads/assets/en/_Overnight%20Stays.pdf' },
   ],
 };
 

--- a/co2eq/lodging.js
+++ b/co2eq/lodging.js
@@ -10,7 +10,7 @@ export const modelVersion = '1';
 export const explanation = {
   text: 'Calculations take into account the energy usage of a stay',
   links: [
-    { label: 'DEFRA (2009)', href: 'https://shop.southpolecarbon.com/uploads/assets/en/_Overnight%20Stays.pdf' },
+    { label: 'UK GOV DEFRA (2009)', href: 'https://shop.southpolecarbon.com/uploads/assets/en/_Overnight%20Stays.pdf' },
   ],
 };
 

--- a/co2eq/meal.js
+++ b/co2eq/meal.js
@@ -24,7 +24,7 @@ export const explanation = {
   // TODO(olc): Write a description for mealType as well.
   text: 'The calculations take into consideration emissions across the whole lifecycle.',
   links: [
-    { label: 'Environmental impact of omnivorous, ovo-lacto-vegetarian, and vegan diet', href: 'https://www.nature.com/articles/s41598-017-06466-8' },
+    { label: 'Nature (2017)', href: 'https://www.nature.com/articles/s41598-017-06466-8' },
     { label: 'Tomorrow footprint database', href: 'https://github.com/tmrowco/tmrowapp-contrib/blob/master/co2eq/purchase/footprints.yml' },
   ],
 };

--- a/co2eq/transportation.js
+++ b/co2eq/transportation.js
@@ -20,7 +20,7 @@ export const explanation = {
   links: [
     { label: 'Ducky (2019)', href: 'https://static.ducky.eco/calculator_documentation.pdf' },
     { label: 'European Cyclists’ Federation (2011)', href: 'https://ecf.com/files/wp-content/uploads/ECF_BROCHURE_EN_planche.pdf' },
-    { label: 'UK GOV (2019)', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
+    { label: 'UK GOV DEFRA (2019)', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
     { label: 'myclimate (2019)', href: 'https://www.myclimate.org/fileadmin/user_upload/myclimate_-_home/01_Information/01_About_myclimate/09_Calculation_principles/Documents/myclimate-flight-calculator-documentation_EN.pdf' },
     { label: 'IOP Science (2019)', href: 'https://iopscience.iop.org/article/10.1088/1748-9326/ab2da8' },
   ],

--- a/co2eq/transportation.js
+++ b/co2eq/transportation.js
@@ -20,7 +20,7 @@ export const explanation = {
   links: [
     { label: 'Ducky (2019)', href: 'https://static.ducky.eco/calculator_documentation.pdf' },
     { label: 'European Cyclists’ Federation (2011)', href: 'https://ecf.com/files/wp-content/uploads/ECF_BROCHURE_EN_planche.pdf' },
-    { label: 'DEFRA (2019)', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
+    { label: 'UK GOV (2019)', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
     { label: 'myclimate (2019)', href: 'https://www.myclimate.org/fileadmin/user_upload/myclimate_-_home/01_Information/01_About_myclimate/09_Calculation_principles/Documents/myclimate-flight-calculator-documentation_EN.pdf' },
     { label: 'IOP Science (2019)', href: 'https://iopscience.iop.org/article/10.1088/1748-9326/ab2da8' },
   ],

--- a/co2eq/transportation.js
+++ b/co2eq/transportation.js
@@ -18,12 +18,11 @@ export const modelVersion = '10';
 export const explanation = {
   text: 'Calculations take into account direct emissions from burning fuel and manufacturing of vehicle.',
   links: [
-    { label: 'Ducky Climate calculator - documentation', href: 'https://static.ducky.eco/calculator_documentation.pdf' },
-    { label: 'Quantifying CO2 savings of cycling - European Cyclists’ Federation', href: 'https://ecf.com/files/wp-content/uploads/ECF_BROCHURE_EN_planche.pdf.pdf' },
-    { label: 'Greenhouse gas reporting: conversion factors 2019 - DEFRA', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
-    { label: 'The myclimate Flight Emission Calculator - myclimate.org', href: 'https://www.myclimate.org/fileadmin/user_upload/myclimate_-_home/01_Information/01_About_myclimate/09_Calculation_principles/Documents/myclimate-flight-calculator-documentation_EN.pdf' },
-    { label: 'The environmental impacts of shared dockless electric scooters', href: 'https://iopscience.iop.org/article/10.1088/1748-9326/ab2da8' },
-    { label: 'The myclimate Flight Emission Calculator', href: 'https://www.myclimate.org/fileadmin/user_upload/myclimate_-_home/01_Information/01_About_myclimate/09_Calculation_principles/Documents/myclimate-flight-calculator-documentation_EN.pdf' },
+    { label: 'Ducky (2019)', href: 'https://static.ducky.eco/calculator_documentation.pdf' },
+    { label: 'European Cyclists’ Federation (2011)', href: 'https://ecf.com/files/wp-content/uploads/ECF_BROCHURE_EN_planche.pdf' },
+    { label: 'DEFRA (2019)', href: 'https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2019' },
+    { label: 'myclimate (2019)', href: 'https://www.myclimate.org/fileadmin/user_upload/myclimate_-_home/01_Information/01_About_myclimate/09_Calculation_principles/Documents/myclimate-flight-calculator-documentation_EN.pdf' },
+    { label: 'IOP Science (2019)', href: 'https://iopscience.iop.org/article/10.1088/1748-9326/ab2da8' },
   ],
 };
 


### PR DESCRIPTION
Problem it solves:
![Screenshot 2020-01-27 at 17 11 41](https://user-images.githubusercontent.com/20746301/73193075-4d53f080-412a-11ea-911e-91e97589804c.jpg)

Also the titles are probably less relevant to users than the sources (publication) So: 
"Environmental impact of omnivorous, ovo-lacto-vegetarian, and vegan diet"
becomes
"Nature 2017"


